### PR TITLE
Fix sleep duration calculation

### DIFF
--- a/src/withings_api.py
+++ b/src/withings_api.py
@@ -167,8 +167,19 @@ class WithingsAPI:
             
             record = {
                 'date': date,
-                # total sleep time is provided in seconds; convert to hours
-                'sleep_duration': (sleep_session.get('enddate', sleep_session['startdate']) - sleep_session['startdate']) / 3600,
+                # calculate duration using timestamps if possible
+                'sleep_duration': (
+                    (sleep_session['enddate'] - sleep_session['startdate']) / 3600
+                    if sleep_session.get('enddate')
+                    else (
+                        (
+                            sleep_session.get('data', {}).get('deepsleepduration', 0)
+                            + sleep_session.get('data', {}).get('lightsleepduration', 0)
+                            + sleep_session.get('data', {}).get('remsleepduration', 0)
+                        )
+                        / 60
+                    )
+                ),
                 'deep_sleep': sleep_session.get('data', {}).get('deepsleepduration', 0) / 60,
                 'light_sleep': sleep_session.get('data', {}).get('lightsleepduration', 0) / 60,
                 'rem_sleep': sleep_session.get('data', {}).get('remsleepduration', 0) / 60,


### PR DESCRIPTION
## Summary
- compute sleep duration from start and end timestamps

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'streamlit')*

------
https://chatgpt.com/codex/tasks/task_e_687378ae0e4c832db5716717b166b518

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the accuracy of sleep duration calculations by basing them on the difference between start and end times, rather than a previously used data field.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->