### PR TITLE
Fix Withings connection error

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,7 @@
 STRAVA_CLIENT_ID=your_client_id_here
 STRAVA_CLIENT_SECRET=your_client_secret_here
 STRAVA_REDIRECT_URI=http://localhost:8501
+
+WITHINGS_CLIENT_ID=your_withings_client_id_here
+WITHINGS_CLIENT_SECRET=your_withings_client_secret_here
+WITHINGS_REDIRECT_URI=http://localhost:8501

--- a/src/app.py
+++ b/src/app.py
@@ -110,10 +110,16 @@ def main():
         st.subheader("🏥 Withings Health Data")
         if not withings_auth.is_authenticated():
             st.write("Connect your Withings account first to analyze your health data.")
-            
+
             if st.button("Connect to Withings"):
-                withings_auth_url = withings_auth.get_authorization_url()
-                st.markdown(f'<a href="{withings_auth_url}" target="_self">Click here to authorize Withings</a>', unsafe_allow_html=True)
+                try:
+                    withings_auth_url = withings_auth.get_authorization_url()
+                    st.markdown(
+                        f'<a href="{withings_auth_url}" target="_self">Click here to authorize Withings</a>',
+                        unsafe_allow_html=True,
+                    )
+                except Exception as e:
+                    st.error(str(e))
         else:
             st.success("✅ Connected to Withings")
             if st.button("Disconnect Withings"):


### PR DESCRIPTION
## Summary
- avoid crashing when Withings credentials are missing
- include Withings variables in the example `.env`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'streamlit')*

------
https://chatgpt.com/codex/tasks/task_e_6873b93e1e8c832da8ac27d8ebdcc4c8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added error handling for the Withings connection process. Users will now see a clear error message if there is an issue retrieving the Withings authorization link, improving overall reliability.

* **Chores**
  * Updated environment variable examples to include placeholders for Withings API credentials and redirect URI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->